### PR TITLE
0.24.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+# Motivations
+
+<!-- * Why are you making modifications? What are you trying to achieve? -->
+
+# Modifications
+
+* <!-- * What modifications have been made to achieve your motivation? -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
 # Motivations
-
-<!-- * Why are you making modifications? What are you trying to achieve? -->
+<!-- * What's the reason you're making modifications? What're you trying to achieve? -->
 
 # Modifications
-
-* <!-- * What modifications have been made to achieve your motivation? -->
+<!-- * What modifications have been made to achieve your motivations? -->
+- 

--- a/charts/palworld/Chart.yaml
+++ b/charts/palworld/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: palworld
-version: 0.24.2-preview
+version: 0.24.0
 description: Official helm chart for the palworld-server-docker docker image, used for deploying a PalWorld Server in Kubernetes
 type: application
 keywords:

--- a/charts/palworld/Chart.yaml
+++ b/charts/palworld/Chart.yaml
@@ -31,7 +31,7 @@ annotations:
       url: https://github.com/thijsvanloef/palworld-server-docker
   artifacthub.io/images: |
     - name: palworld-server-docker
-      image: thijsvanloef/palworld-server-docker:0.24.2
+      image: thijsvanloef/palworld-server-docker:v0.24.2
   artifacthub.io/screenshots: |
     - title: PalWorld
       url: https://cdn.akamai.steamstatic.com/steam/apps/1623730/header.jpg

--- a/charts/palworld/Chart.yaml
+++ b/charts/palworld/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: palworld
-version: 0.24.2
+version: 0.24.2-preview
 description: Official helm chart for the palworld-server-docker docker image, used for deploying a PalWorld Server in Kubernetes
 type: application
 keywords:

--- a/charts/palworld/Chart.yaml
+++ b/charts/palworld/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: palworld
-version: 0.1.1
+version: 0.24.2
 description: Official helm chart for the palworld-server-docker docker image, used for deploying a PalWorld Server in Kubernetes
 type: application
 keywords:
@@ -31,7 +31,7 @@ annotations:
       url: https://github.com/thijsvanloef/palworld-server-docker
   artifacthub.io/images: |
     - name: palworld-server-docker
-      image: thijsvanloef/palworld-server-docker:latest
+      image: thijsvanloef/palworld-server-docker:0.24.2
   artifacthub.io/screenshots: |
     - title: PalWorld
       url: https://cdn.akamai.steamstatic.com/steam/apps/1623730/header.jpg

--- a/charts/palworld/Chart.yaml
+++ b/charts/palworld/Chart.yaml
@@ -19,7 +19,7 @@ maintainers:
 - name: Twinki14
   url: https://github.com/Twinki14
 icon: https://cdn.akamai.steamstatic.com/steam/apps/1623730/header.jpg
-appVersion: "0.24.2"
+appVersion: "v0.24.2"
 deprecated: false
 annotations:
   artifacthub.io/alternativeName: palworld-server

--- a/charts/palworld/Chart.yaml
+++ b/charts/palworld/Chart.yaml
@@ -19,7 +19,7 @@ maintainers:
 - name: Twinki14
   url: https://github.com/Twinki14
 icon: https://cdn.akamai.steamstatic.com/steam/apps/1623730/header.jpg
-appVersion: "latest"
+appVersion: "0.24.2"
 deprecated: false
 annotations:
   artifacthub.io/alternativeName: palworld-server

--- a/charts/palworld/templates/configmaps.yaml
+++ b/charts/palworld/templates/configmaps.yaml
@@ -44,8 +44,8 @@ data:
   SERVER_DESCRIPTION: {{ .Values.server.config.server_description }}
   UPDATE_ON_BOOT: {{ .Values.server.config.update_on_boot | quote }}
   QUERY_PORT: {{ .Values.server.config.query_port | quote }}
-  {{ if .Values.server.config.world_parameters }}
-  {{- with .Values.server.config.world_parameters }}
+  {{ if .Values.server.config.env }}
+  {{- with .Values.server.config.env }}
   {{- toYaml . | nindent 2  }}
   {{- end }}
   {{ if .Values.server.config.daily_reboot.enable }}

--- a/charts/palworld/templates/deployments.yaml
+++ b/charts/palworld/templates/deployments.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/palworld/templates/deployments.yaml
+++ b/charts/palworld/templates/deployments.yaml
@@ -39,6 +39,10 @@ spec:
         - name: server
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: {{ .Values.server.image.imagePullPolicy }}
+          {{- with .Values.server.image.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
           lifecycle:
             preStop:
               exec:

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -40,12 +40,14 @@ server:
   - name: game
     containerPort: 8211
     protocol: UDP
+
   - name: query
     containerPort: 27015
     protocol: UDP
+
   - name: rcon
     containerPort: 25575
-    protocol: UDP
+    protocol: TCP
 
   # Deployment strategy
   #
@@ -88,7 +90,7 @@ server:
 
     - name: rcon
       port: 25575
-      protocol: UDP
+      protocol: TCP
       targetPort: 25575
 
   # Palworld-server specific configuration

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -144,6 +144,7 @@ server:
       serviceAccount: "daily-reboot"
 
     # Any additional environment variables related to the palworld-server-docker image
+    # Note, it's recommended to wrap values of the environment variables in quotes
     #
     env:
 

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -1,13 +1,12 @@
-# -- Namespace where the resources will be created
-namespace: palworld
-# -- (dict) The server configuration
-# @notationType -- bigValue
+# Namespace where the resources will be created
+#
+namespace: palworld-server
+
+# General annotations, labels, and resources limits for the resources
+#
 server:
-  # -- Additional annotations to the resources
   annotations: {}
-  # -- Additional labels to the resources
   labels: {}
-  # -- (dict) Resources limits for the container.
   resources:
     limits:
       cpu: 4
@@ -15,66 +14,57 @@ server:
     requests:
       cpu: 4
       memory: "8Gi"
-  # -- (dict) Define some parameters for the storage volume
+
+  # Storage definitions related to the palworld-server
+  #
   storage:
-    # -- (bool) Define if it will use an existing PVC containing the installation data.
+    # -- Use an existing PVC
     external: false
-    # -- (bool) The external PVC name to use.
     externalName: ""
-    # -- Keeps helm from deleting the PVC. By default, helm does not delete pvcs.
+    # -- Keeps helm from deleting the PVC, by default helm does not delete pvcs
     preventDelete: false
-    # -- The size of the pvc storage.
     size: 12Gi
-    # -- The storage class name.
     storageClassName: ""
-  # -- (dict) Define the parameters for the server image container
-  # @notationType -- bigValue
+
+  # Docker image used for the palworld-server deployment
+  #
   image:
-    # -- Repository of the image, without the tag.
     repository: thijsvanloef/palworld-server-docker
-    # -- The tag of the image.
-    tag: 0.24.2
-    # -- Define the pull policy for the server image.
+    tag: latest
     imagePullPolicy: IfNotPresent
 
-  # -- (dict) Change the ports to be mapped to the pod.
-  # If you change those, make sure to change the service.ports and server.config accordingly.
-  # @notationType -- bigValue
+  # Server-related ports
+  # Be sure your service.ports and config.ports matches this section
+  #
   ports:
-  # -- (dict) The "game" port definition.
-  # If you change this, make sure to change the service.ports.game and server.config accordingly.
   - name: game
     containerPort: 8211
     protocol: UDP
   - name: query
-    # -- (dict) The "query" port definition .
-    # If you change this, make sure to change the service.ports.query_port and server.config accordingly.
     containerPort: 27015
     protocol: UDP
   - name: rcon
-    # -- (dict) The "rcon" port definition .
-    # If you change this, make sure to change the service.ports.rcon and server.config accordingly.
     containerPort: 25575
     protocol: UDP
-  # -- (string) Change the deployment strategy
+
+  # Deployment strategy
+  #
   strategy: Recreate
 
-  # -- (dict) Change the service configuration.
-  # If you change those, make sure to change the server.config and server.ports accordingly.
-  # @notationType -- bigValue
+  # Service configuration
+  # 
   service:
-    # -- (bool) Enables the creation of the service component.
     enabled: true
-    # -- Additional annotations to the resources
     annotations: {}
-    # -- Additional labels to the resources
     labels: {}
-    # -- (string) The type of service to be created.
+
     # For minikube, set this to NodePort, elsewhere use LoadBalancer
     # Use ClusterIP if your setup includes ingress controller
+    #
     type: ClusterIP
-    # -- (dict) The "healthz" definition .
+
     # Use if you need to create a TCP health check for load balancers on cloud services.
+    #
     healthz:
       enabled: false
       name: healthz
@@ -82,145 +72,78 @@ server:
       protocol: TCP
       targetPort: 80
 
-    # -- (dict) Change the ports to be mapped to the service.
-    # If you change those, make sure to change the server.config and server.ports accordingly.
-    # @notationType -- bigValue
+    # Port definitions for the service
+    # Be sure this matches the config section
+    #
     ports:
-
-    # -- (dict) The "game" port definition.
-    # If you change this, make sure to change the server.ports.game and server.config.port accordingly.
     - name: game
       port: 8211
       protocol: UDP
       targetPort: 8211
 
-    # If you change this, make sure to change the server.ports.query and server.config.query_port accordingly.
     - name: query
-      # -- (dict) The "query" port definition .
       port: 27015
       protocol: UDP
       targetPort: 27015
 
-    # If you change this, make sure to change the server.ports.rcon and server.config.rcon.port accordingly.
     - name: rcon
-      # -- (dict) The "rcon" port definition .
       port: 25575
       protocol: UDP
       targetPort: 25575
 
-  # -- (dict) Change the game server configuration.
-  # If you change those, make sure to change the service.ports and server.ports accordingly.
-  # Those are directly connected with the container image, providing multiple environment variables to the scripts.
-  # @notationType -- bigValue
+  # Palworld-server specific configuration
+  #
   config:
-    # -- Additional annotations to the resources
     annotations: {}
-    # -- Additional labels to the resources
     labels: {}
     puid: 1000
     pgid: 1000
     port: 8211
-    # -- (string) The query port of the game.
     query_port: 27015
-    # -- The max number of players supported.
     max_players: 16
-    # -- (bool) Enables the multithreading, allowing the usage of up to 4 cores (needs citation)
     multithreading: true
-    # -- (dict) Remote connection configuration.
-    # Allows the remote connection and management for the server.
-    # Those are directly connected with the container image, providing multiple environment variables to the scripts.
-    # @notationType -- bigValue
     rcon:
-      # -- (bool) Enables/disables the rcon port.
       enable: true
-      # -- (string) The port for rcon. If you change this, make sure to change the service.ports and server.ports accordingly.
       port: 25575
-      # -- (string) If not provided, a random password will be generated and stored on the secret.
+
+      # If not provided a random password will be generated and stored as a secret
+      # 
       password: ""
+
+    # Community server settings
+    #
     community:
-      # -- (bool) Enables/disables the visibility of this server on Steam community servers list.
       enable: true
-      # -- (string) If not provided, a random password will be generated and stored on the secret.
       password: ""
-      # -- (string) If not provided, a random server name will be generated with the "palworld_" prefix.
+
+    # General server settings
     server_name: ""
-    # -- (string) The timezone used for time stamping backup server. Use the IANA TZ format with Area/Location
-    # See the [list of TZ database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#Time_Zone_abbreviations)
     timezone: "UTC"
-    # -- (string) You can manually specify the global IP address of the network on which the server running.
-    # If not specified, it will be detected automatically. If it does not work well, try manual configuration.
     public_ip: ""
-    # -- (string) You can manually specify the port number of the network on which the server running.
-    # If not specified, it will be detected automatically. If it does not work well, try manual configuration.
     public_port: ""
-    # -- (string) Your server description to be shown in game
     server_description: ""
-    # -- (string) Update/Install the server when the container starts.
-    # THIS HAS TO BE ENABLED THE FIRST TIME YOU RUN THE CONTAINER
+
+    # Update or install the server when the container starts
+    # Must be enabled when the container first starts
+    #
     update_on_boot: true
+
+    # Daily reboot configuration, disabled by default
+    #
     daily_reboot:
-      # -- (bool) Enable daily reboot.
-      # Disabled by default
       enable: false
-      # -- (string) Time (UTC) the server will perform the reboot.
-      # By default, this schedules the restart at 9:30am UTC. Please note, this is using cron syntax.
+
+      # UTC cron syntax for server reboot schedule, https://crontab.guru/
+      # Defaults to 9:30am UTC
+      #
       time: "30 9 * * *"
-      # -- (string) Name of the role performing the daily reboot.
+
+      # Name of the role and service account used to perform the daily reboot
+      #
       role: "daily-reboot"
-      # -- (string) Name of the Service Account used to perform the reboot.
       serviceAccount: "daily-reboot"
 
+    # Any additional environment variables related to the palworld-server-docker image
+    #
+    env:
 
-    world_parameters:
-      DAYTIME_SPEEDRATE: "1.000000"
-      NIGHTTIME_SPEEDRATE: "1.000000"
-      EXP_RATE: "1.000000"
-      PAL_CAPTURE_RATE: "1.000000"
-      PAL_SPAWN_NUM_RATE: "1.000000"
-      PAL_DAMAGE_RATE_ATTACK: "1.000000"
-      PAL_DAMAGE_RATE_DEFENSE: "1.000000"
-      PLAYER_DAMAGE_RATE_ATTACK: "1.000000"
-      PLAYER_DAMAGE_RATE_DEFENSE: "1.000000"
-      PLAYER_STOMACH_DECREASE_RATE: "1.000000"
-      PLAYER_STAMINA_DECREASE_RATE: "1.000000"
-      PLAYER_AUTO_HP_REGEN_RATE: "1.000000"
-      PLAYER_AUTO_HP_REGEN_RATE_IN_SLEEP: "1.000000"
-      PAL_STOMACH_DECREASE_RATE: "1.000000"
-      PAL_STAMINA_DECREASE_RATE: "1.000000"
-      PAL_AUTO_HP_REGEN_RATE: "1.000000"
-      PAL_AUTO_HP_REGEN_RATE_IN_SLEEP: "1.000000"
-      BUILD_OBJECT_DAMAGE_RATE: "1.000000"
-      BUILD_OBJECT_DETERIORATION_DAMAGE_RATE: "1.000000"
-      COLLECTION_DROP_RATE: "1.000000"
-      COLLECTION_OBJECT_HP_RATE: "1.000000"
-      COLLECTION_OBJECT_RESPAWN_SPEED_RATE: "1.000000"
-      ENEMY_DROP_ITEM_RATE: "1.000000"
-      DEATH_PENALTY: "All"
-      ENABLE_PLAYER_TO_PLAYER_DAMAGE: "False"
-      ENABLE_FRIENDLY_FIRE: "False"
-      ENABLE_INVADER_ENEMY: "True"
-      ACTIVE_UNKO: "True"
-      ENABLE_AIM_ASSIST_PAD: "True"
-      ENABLE_AIM_ASSIST_KEYBOARD: "False"
-      DROP_ITEM_MAX_NUM: "3000"
-      DROP_ITEM_MAX_NUM_UNKO: "1000"
-      BASE_CAMP_MAX_NUM: "128"
-      BASE_CAMP_WORKER_MAX_NUM: "15"
-      DROP_ITEM_ALIVE_MAX_HOURS: "1.000000"
-      AUTO_RESET_GUILD_NO_ONLINE_PLAYERS: "False"
-      AUTO_RESET_GUILD_TIME_NO_ONLINE_PLAYERS: "72.000000"
-      GUILD_PLAYER_MAX_NUM: "3"
-      PAL_EGG_DEFAULT_HATCHING_TIME: "72.000000"
-      WORK_SPEED_RATE: "1.000000"
-      IS_MULTIPLAY: "False"
-      IS_PVP: "False"
-      CAN_PICKUP_OTHER_GUILD_DEATH_PENALTY_DROP: "False"
-      ENABLE_NON_LOGIN_PENALTY: "True"
-      ENABLE_FAST_TRAVEL: "True"
-      IS_START_LOCATION_SELECT_BY_MAP: "True"
-      EXIST_PLAYER_AFTER_LOGOUT: "False"
-      ENABLE_DEFENSE_OTHER_GUILD_PLAYER: "False"
-      COOP_PLAYER_MAX_NUM: "4"
-      REGION: ""
-      USEAUTH: "True"
-      BAN_LIST_URL: "https://api.palworldgame.com/api/banlist.txt"

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -18,11 +18,13 @@ server:
   # Storage definitions related to the palworld-server
   #
   storage:
-    # -- Use an existing PVC
     external: false
     externalName: ""
-    # -- Keeps helm from deleting the PVC, by default helm does not delete pvcs
+
+    # Keeps helm from deleting the PVC, by default helm does not delete pvcs
+    #
     preventDelete: false
+
     size: 12Gi
     storageClassName: ""
 

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -1,8 +1,4 @@
-# Namespace where the resources will be created
-#
-namespace: palworld-server
-
-# General annotations, labels, and resources limits for the resources
+# Server deployment annotations, labels, and resources limits
 #
 server:
   annotations: {}
@@ -32,8 +28,9 @@ server:
   #
   image:
     repository: thijsvanloef/palworld-server-docker
-    tag: latest
+    tag: v0.24.2
     imagePullPolicy: IfNotPresent
+    imagePullSecrets: []
 
   # Server-related ports
   # Be sure your service.ports and config.ports matches this section
@@ -153,4 +150,3 @@ server:
     # -- https://github.com/thijsvanloef/palworld-server-docker/tree/main 
     #
     env:
-

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -1,4 +1,3 @@
----
 # -- Namespace where the resources will be created
 namespace: palworld
 # -- (dict) The server configuration
@@ -34,7 +33,7 @@ server:
     # -- Repository of the image, without the tag.
     repository: thijsvanloef/palworld-server-docker
     # -- The tag of the image.
-    tag: latest
+    tag: 0.24.2
     # -- Define the pull policy for the server image.
     imagePullPolicy: IfNotPresent
 
@@ -42,21 +41,21 @@ server:
   # If you change those, make sure to change the service.ports and server.config accordingly.
   # @notationType -- bigValue
   ports:
-    # -- (dict) The "game" port definition.
-    # If you change this, make sure to change the service.ports.game and server.config accordingly.
-    - name: game
-      containerPort: 8211
-      protocol: UDP
+  # -- (dict) The "game" port definition.
+  # If you change this, make sure to change the service.ports.game and server.config accordingly.
+  - name: game
+    containerPort: 8211
+    protocol: UDP
+  - name: query
     # -- (dict) The "query" port definition .
     # If you change this, make sure to change the service.ports.query_port and server.config accordingly.
-    - name: query
-      containerPort: 27015
-      protocol: UDP
+    containerPort: 27015
+    protocol: UDP
+  - name: rcon
     # -- (dict) The "rcon" port definition .
     # If you change this, make sure to change the service.ports.rcon and server.config accordingly.
-    - name: rcon
-      containerPort: 25575
-      protocol: UDP
+    containerPort: 25575
+    protocol: UDP
   # -- (string) Change the deployment strategy
   strategy: Recreate
 
@@ -82,28 +81,33 @@ server:
       port: 80
       protocol: TCP
       targetPort: 80
+
     # -- (dict) Change the ports to be mapped to the service.
     # If you change those, make sure to change the server.config and server.ports accordingly.
     # @notationType -- bigValue
     ports:
-      # -- (dict) The "game" port definition.
-      # If you change this, make sure to change the server.ports.game and server.config.port accordingly.
-      - name: game
-        port: 8211
-        protocol: UDP
-        targetPort: 8211
+
+    # -- (dict) The "game" port definition.
+    # If you change this, make sure to change the server.ports.game and server.config.port accordingly.
+    - name: game
+      port: 8211
+      protocol: UDP
+      targetPort: 8211
+
+    # If you change this, make sure to change the server.ports.query and server.config.query_port accordingly.
+    - name: query
       # -- (dict) The "query" port definition .
-      # If you change this, make sure to change the server.ports.query and server.config.query_port accordingly.
-      - name: query
-        port: 27015
-        protocol: UDP
-        targetPort: 27015
+      port: 27015
+      protocol: UDP
+      targetPort: 27015
+
+    # If you change this, make sure to change the server.ports.rcon and server.config.rcon.port accordingly.
+    - name: rcon
       # -- (dict) The "rcon" port definition .
-      # If you change this, make sure to change the server.ports.rcon and server.config.rcon.port accordingly.
-      - name: rcon
-        port: 25575
-        protocol: UDP
-        targetPort: 25575
+      port: 25575
+      protocol: UDP
+      targetPort: 25575
+
   # -- (dict) Change the game server configuration.
   # If you change those, make sure to change the service.ports and server.ports accordingly.
   # Those are directly connected with the container image, providing multiple environment variables to the scripts.
@@ -158,17 +162,15 @@ server:
       # -- (bool) Enable daily reboot.
       # Disabled by default
       enable: false
-      # -- (string) The time (UTC) the server will perform the reboot.
+      # -- (string) Time (UTC) the server will perform the reboot.
       # By default, this schedules the restart at 9:30am UTC. Please note, this is using cron syntax.
       time: "30 9 * * *"
-      # -- (string) The name of the role performing the daily reboot.
+      # -- (string) Name of the role performing the daily reboot.
       role: "daily-reboot"
-      # -- (string) The name of the Service Account used to perform the reboot.
+      # -- (string) Name of the Service Account used to perform the reboot.
       serviceAccount: "daily-reboot"
-    # -- (object) Configures the game world settings.
-    # The key:values here should represent in game accepted values.
-    # Wrap all values with quotes here to avoid validation issues.
-    # @notationType -- bigValue
+
+
     world_parameters:
       DAYTIME_SPEEDRATE: "1.000000"
       NIGHTTIME_SPEEDRATE: "1.000000"

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -144,7 +144,9 @@ server:
       serviceAccount: "daily-reboot"
 
     # Any additional environment variables related to the palworld-server-docker image
-    # Note, it's recommended to wrap values of the environment variables in quotes
+    # -- Note, it's recommended to wrap values of the environment variables in quotes
+    # -- You can find a list of these environment variables in the palworld-server-docker readme 
+    # -- https://github.com/thijsvanloef/palworld-server-docker/tree/main 
     #
     env:
 


### PR DESCRIPTION
# Motivations
Simplification, centralization, and official helm-chart separation 

# Modifications
- Greatly simplify `values.yaml`, reduce the amount of unnecessary documentation to increase readability
- Clamp this chart to a specific `palworld-server-docker` version, starting with `0.24.2`
- Remove `world_parameters` in favor of a generic `env` value, so that we don't have to actively maintain the `values.yaml` with supported environment variables 
- Add a pull request template