### PR TITLE
feat: publish Helm charts in OCI format to GHCR

### DIFF
--- a/.github/workflows/push-helm-chart.yaml
+++ b/.github/workflows/push-helm-chart.yaml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: write
       pages: write
+      packages: write
     steps:
 
     - name: Checkout
@@ -22,6 +23,13 @@ jobs:
         git config user.name "$GITHUB_ACTOR"
         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+    - name: OCI - Login to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
       # Pushes updates to index.yaml found in the gh-pages branch when a new version is detected
     - name: Helm - chart-releaser
       uses: helm/chart-releaser-action@v1.6.0
@@ -33,3 +41,18 @@ jobs:
         config: ./charts/cr.yaml
       env:
         CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+    - name: Helm - OCI Push to GHCR
+      run: |
+        if [ -z "$(ls -A .cr-release-packages)" ]; then
+          echo "No packages found under .cr-release-packages/"
+          exit 0
+        fi
+        for pkg in .cr-release-packages/*; do
+          if [ -z "${pkg:-}" ]; then
+            break
+          fi
+          REPO="${{ github.repository }}"
+          echo "Pushing $pkg to ghcr.io/${REPO,,}"
+          helm push "$pkg" "oci://ghcr.io/${REPO,,}"
+        done


### PR DESCRIPTION
# Motivations
In addition to GitHub Pages for Helm chart releases, the OCI format can be used to publish Helm charts. After this, charts can be referenced via the OCI url with `oci://ghcr.io/twinki14/palworld-server-chart/palworld` i.e. `helm repo add palworld-server oci://ghcr.io/twinki14/palworld-server-chart`

# Modifications
This adds steps to the release workflow to login to GHCR and push the charts generated by `helm/chart-releaser-action` up to GHCR
