### PR TITLE
fix: imagePullSecrets

### DIFF
--- a/charts/palworld/templates/deployments.yaml
+++ b/charts/palworld/templates/deployments.yaml
@@ -39,10 +39,6 @@ spec:
         - name: server
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: {{ .Values.server.image.imagePullPolicy }}
-          {{- with .Values.server.image.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
           lifecycle:
             preStop:
               exec:
@@ -70,6 +66,10 @@ spec:
           volumeMounts:
             - mountPath: /palworld
               name: datadir
+      {{- with .Values.server.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: datadir
           persistentVolumeClaim:


### PR DESCRIPTION
Sorry for the PR spam!

# Motivations
The `imagePullSecrets` aren't _quite_ in the right place.

This can be seen by templating the chart with `helm template palworld oci://ghcr.io/twinki14/palworld-server-chart/palworld --set 'server.image.imagePullSecrets[0].name=registry-docker-hub'` and observing the Deployment resource

Applying the deployment currently results in an error: `Deployment in version "v1" cannot be handled as a Deployment: strict decoding error: unknown field "spec.template.spec.containers[0].imagePullSecrets"`

# Modifications
`imagePullSecrets` are located in `spec.template.spec` in the `Deployment` resource. Previously this was placed under `spec.template.spec.containers[0]`.

This commit moves the `imagePullSecrets` field to the correct location.
