### PR TITLE
feat: Add chart-testing and e2e test

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -1,0 +1,48 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Supported versions at https://kubernetes.io/releases/
+        version:
+        - v1.26.13 # EOL 2024-02-28
+        - v1.27.10 # EOL 2024-06-28
+        - v1.28.6 # EOL 2024-10-28
+        - v1.29.1 # EOL 2025-02-28
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Helm - chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          install_only: true
+
+      - name: Helm - chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+
+      - name: Helm - chart-testing - list-changed
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Helm - chart-testing - lint
+        run: ct lint --config ct.yaml
+
+      - name: K8S - Create Kind Cluster
+        uses: helm/kind-action@v1.8.0
+        with:
+          node_image: kindest/node:${{ matrix.version }}
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Helm - chart-testing - install
+        run: ct install --config ct.yaml --helm-extra-set-args='--set=server.resources=null --set=server.storage.size=3Gi'

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -3,7 +3,34 @@ name: Lint and Test Charts
 on: pull_request
 
 jobs:
-  lint-test:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Helm - chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          install_only: true
+
+      - name: Helm - chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+
+      - name: Helm - chart-testing - list-changed
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Helm - chart-testing - lint
+        run: ct lint --config ct.yaml
+
+  e2e-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -34,9 +61,6 @@ jobs:
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
-
-      - name: Helm - chart-testing - lint
-        run: ct lint --config ct.yaml
 
       - name: K8S - Create Kind Cluster
         uses: helm/kind-action@v1.8.0

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -2,6 +2,10 @@ name: Lint and Test Charts
 
 on: pull_request
 
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/charts/palworld/Chart.yaml
+++ b/charts/palworld/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: palworld
-version: 0.24.1
+version: 0.24.3
 description: Official helm chart for the palworld-server-docker docker image, deploys a dedicated PalWorld server to your Kubernetes cluster!
 type: application
 keywords:

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -53,7 +53,7 @@ server:
   strategy: Recreate
 
   # Service configuration
-  # 
+  #
   service:
     enabled: true
     annotations: {}
@@ -108,7 +108,7 @@ server:
       port: 25575
 
       # If not provided a random password will be generated and stored as a secret
-      # 
+      #
       password: ""
 
     # Community server settings
@@ -146,7 +146,7 @@ server:
 
     # Any additional environment variables related to the palworld-server-docker image
     # -- Note, it's recommended to wrap values of the environment variables in quotes
-    # -- You can find a list of these environment variables in the palworld-server-docker readme 
-    # -- https://github.com/thijsvanloef/palworld-server-docker/tree/main 
+    # -- You can find a list of these environment variables in the palworld-server-docker readme
+    # -- https://github.com/thijsvanloef/palworld-server-docker/tree/main
     #
     env:

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,6 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+target-branch: main
+chart-dirs:
+  - charts
+validate-maintainers: false


### PR DESCRIPTION
# Motivations
Just wanted to throw this together if you want it to help ensure non-breaking changes.

# Modifications
This PR adds a CI workflow that uses Helm's [chart-testing](https://github.com/helm/chart-testing) tool, `ct` to lint the chart.

There is also a matrix job that installs the chart into a KIND (K8s in Docker) cluster in the GitHub actions runner for each currently-supported K8S version, using the [helm/kind-action](https://github.com/helm/kind-action) action.

In order for the pod to get scheduled, I had to modify the  `ct install` command in CI to set the `server.resources` to `null` and reduce the disk to 3Gi (my PVC on a new server shows ~2.3gb in use). The `ct install` command installs the Helm chart and waits for the workload to show as `Running` before tearing the cluster down.

I also fixed the only lint error that popped up, which were just for trailing spaces in the `values.yaml`.

I was going to move the `ct.yaml` file under the `charts/` directory, but (find the link) I found that this causes errors (`charts is not a valid chart directory`) in chart-testing, and https://github.com/helm/chart-testing/issues/226#issuecomment-694718847 points out that this is resolved my moving `ct.yaml` out of the charts directory