### PR TITLE
feat: deployment: redeploy on configmap or secret change

### DIFF
--- a/charts/palworld/Chart.yaml
+++ b/charts/palworld/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: palworld
-version: 0.26.0
+version: 0.26.1
 description: Official helm chart for the palworld-server-docker docker image, deploys a dedicated PalWorld server to your Kubernetes cluster!
 type: application
 keywords:

--- a/charts/palworld/templates/deployments.yaml
+++ b/charts/palworld/templates/deployments.yaml
@@ -15,6 +15,8 @@ spec:
         {{- with .Values.server.annotations }}
         {{- toYaml . | nindent 4 }}
         {{- end }}
+        checksum/configs: {{ include (print $.Template.BasePath "/configmaps.yaml") . | sha256sum }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
       labels:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/name: "{{ .Release.Name }}-server"


### PR DESCRIPTION
# Motivations
Redeploy the server pod when the values configuration changes a `ConfigMap` or `Secret`.

# Modifications
- This PR places the sha256 checksum digests of the post-rendered `configmaps.yaml` and `secrets.yaml` in the annotations of the `Deployment`'s pod template so that a new pod is deployed whenever these resources change due to a change in the chart values by user configuration
