### PR TITLE
fix(security): move potentially-sensitive SERVER_PASSWORD to a secret

### DIFF
--- a/charts/palworld/Chart.yaml
+++ b/charts/palworld/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: palworld
-version: 0.26.1
+version: 0.26.2
 description: Official helm chart for the palworld-server-docker docker image, deploys a dedicated PalWorld server to your Kubernetes cluster!
 type: application
 keywords:

--- a/charts/palworld/templates/configmaps.yaml
+++ b/charts/palworld/templates/configmaps.yaml
@@ -1,4 +1,3 @@
-{{- $cPwd := randAlphaNum 12 | nospace -}}
 {{- $sName := "" -}}
 apiVersion: v1
 kind: ConfigMap
@@ -31,7 +30,6 @@ data:
   {{ end }}
   {{ if .Values.server.config.community.enable }}
   COMMUNITY: "true"
-  SERVER_PASSWORD: {{- if .Values.server.config.community.password }} "{{ .Values.server.config.community.password }}" {{ else }} {{ $cPwd }} {{ end }}
   {{ end }}
   {{ if .Values.server.config.server_name }}
   SERVER_NAME: {{ regexReplaceAll "\\W+" .Values.server.config.server_name "_" }}

--- a/charts/palworld/templates/deployments.yaml
+++ b/charts/palworld/templates/deployments.yaml
@@ -62,6 +62,13 @@ spec:
                 secretKeyRef:
                   name: "{{ .Release.Name }}-rcon-password"
                   key: "rconPassword"
+            {{- if .Values.server.config.community.enable }}
+            - name: SERVER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-community-password"
+                  key: "communityPassword"
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: "{{ .Release.Name }}-env-config"

--- a/charts/palworld/templates/secrets.yaml
+++ b/charts/palworld/templates/secrets.yaml
@@ -1,6 +1,9 @@
 {{- define "server.rcon.password" -}}
 {{- randAlphaNum 24 | nospace -}}
 {{- end -}}
+{{- define "server.community.password" -}}
+{{- randAlphaNum 24 | nospace -}}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -23,3 +26,28 @@ metadata:
 type: Opaque
 stringData:
   rconPassword: {{- if .Values.server.config.rcon.password }} "{{ .Values.server.config.rcon.password }}" {{ else }} "{{ include "server.rcon.password" .}}" {{ end }}
+---
+{{- if .Values.server.config.community.enable }}
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: {{ .Values.namespace }}
+  name: "{{ .Release.Name }}-community-password"
+  annotations:
+    {{- with .Values.server.config.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: "{{ .Release.Name }}-community-password"
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "{{ .Release.Name }}-community-password"
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- with .Values.server.config.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+type: Opaque
+stringData:
+  communityPassword: {{- if .Values.server.config.community.password }} "{{ .Values.server.config.community.password }}" {{ else }} "{{ include "server.community.password" .}}" {{ end }}
+{{- end }}


### PR DESCRIPTION
# Motivations
This should let k8s admins handle RBAC for the server password as it could be considered sensitive.

# Modifications
- This PR removes the `SERVER_PASSWORD` from the `ConfigMap`, opting to create a dedicated `Secret` for the server password and loading it via `valueFrom` on the Deployment pod spec, mirroring the way the RCON password is handled
