### PR TITLE
feat: allow using external secrets for RCON and community passwords

### DIFF
--- a/charts/palworld/Chart.yaml
+++ b/charts/palworld/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: palworld
-version: 0.26.2
+version: 0.26.3
 description: Official helm chart for the palworld-server-docker docker image, deploys a dedicated PalWorld server to your Kubernetes cluster!
 type: application
 keywords:

--- a/charts/palworld/templates/deployments.yaml
+++ b/charts/palworld/templates/deployments.yaml
@@ -60,14 +60,24 @@ spec:
             - name: ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
+                {{- if not .Values.server.config.rcon.externalPassword }}
                   name: "{{ .Release.Name }}-rcon-password"
                   key: "rconPassword"
+                {{- else }}
+                  name: "{{ .Values.server.config.rcon.externalPassword.name }}"
+                  key: "{{ .Values.server.config.rcon.externalPassword.key }}"
+                {{- end }}
             {{- if .Values.server.config.community.enable }}
             - name: SERVER_PASSWORD
               valueFrom:
                 secretKeyRef:
+                {{- if not .Values.server.config.community.externalPassword }}
                   name: "{{ .Release.Name }}-community-password"
                   key: "communityPassword"
+                {{- else }}
+                  name: "{{ .Values.server.config.community.externalPassword.name }}"
+                  key: "{{ .Values.server.config.community.externalPassword.key }}"
+                {{- end }}
             {{- end }}
           envFrom:
             - configMapRef:

--- a/charts/palworld/templates/secrets.yaml
+++ b/charts/palworld/templates/secrets.yaml
@@ -4,6 +4,7 @@
 {{- define "server.community.password" -}}
 {{- randAlphaNum 24 | nospace -}}
 {{- end -}}
+{{- if not .Values.server.config.rcon.externalPassword }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -26,8 +27,9 @@ metadata:
 type: Opaque
 stringData:
   rconPassword: {{- if .Values.server.config.rcon.password }} "{{ .Values.server.config.rcon.password }}" {{ else }} "{{ include "server.rcon.password" .}}" {{ end }}
+{{- end }}
 ---
-{{- if .Values.server.config.community.enable }}
+{{- if and .Values.server.config.community.enable (not .Values.server.config.community.externalPassword) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -111,11 +111,21 @@ server:
       #
       password: ""
 
+      # If provided, the password will be loaded from an existing secret
+      externalPassword: {}
+        # The name of the secret containing the rcon password
+        # name: ""
+        # The key in the secret containing the rcon password
+        # key: ""
+
     # Community server settings
     #
     community:
       enable: true
       password: ""
+      externalPassword: {}
+        # name: ""
+        # key: ""
 
     # General server settings
     server_name: ""


### PR DESCRIPTION
# Motivations
For folks who host their K8S gitops repos publicly, having charts that allow secrets to be injected externally is important for both preventing any sort of secret-commiting mishap and visually clarifying which secrets will need to specified externally instead of (current approach) making the `Secret` keys opaque and using the gitops provider's features to inject the secrets, support of which can vary.

Also this avoids the weirdness of having a secret injected, meanwhile the values read `password: ""` as if there is none

# Modifications
- This allows the `valueFrom` s to be overridden by the values.
- There are no breaking changes as the `externalPassword` value only overrides the existing defaults when it is specified.
