### PR TITLE
fix: use namespace provided by Helm rather than the Values.namespace

### DIFF
--- a/charts/palworld/Chart.yaml
+++ b/charts/palworld/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: palworld
-version: 0.26.3
+version: 0.26.4
 description: Official helm chart for the palworld-server-docker docker image, deploys a dedicated PalWorld server to your Kubernetes cluster!
 type: application
 keywords:

--- a/charts/palworld/templates/configmaps.yaml
+++ b/charts/palworld/templates/configmaps.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   name: "{{ .Release.Name }}-env-config"
   annotations:
     {{- with .Values.server.config.annotations }}
@@ -49,10 +49,10 @@ data:
   {{ if .Values.server.config.daily_reboot.enable }}
   restart-deployment.sh:  |
     #!/bin/bash
-    cont=$(kubectl -n {{ .Values.namespace }} get pods -o=jsonpath='{.items[?(@.metadata.labels.app\.kubernetes\.io/name=="{{ .Release.Name }}-server")].metadata.name}')
+    cont=$(kubectl -n {{ .Release.Namespace }} get pods -o=jsonpath='{.items[?(@.metadata.labels.app\.kubernetes\.io/name=="{{ .Release.Name }}-server")].metadata.name}')
     
     function exec_rcon_cmd() {
-      kubectl exec -n {{ .Values.namespace }} -i pod/$cont rcon-cli "$1"
+      kubectl exec -n {{ .Release.Namespace }} -i pod/$cont rcon-cli "$1"
     }
     
     exec_rcon_cmd "Broadcast Saving_Server_Data..."
@@ -70,6 +70,6 @@ data:
 
     exec_rcon_cmd "Shutdown 1"
     sleep 30
-    kubectl -n {{ .Values.namespace }} rollout restart deployment/{{ .Release.Name }}-server
+    kubectl -n {{ .Release.Namespace }} rollout restart deployment/{{ .Release.Name }}-server
   {{ end }}
   {{ end }}

--- a/charts/palworld/templates/cronjob.yaml
+++ b/charts/palworld/templates/cronjob.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: "{{ .Values.server.config.daily_reboot.serviceAccount }}"
-  namespace:  {{ .Values.namespace }}
+  namespace:  {{ .Release.Namespace }}
 spec:
   concurrencyPolicy:  Forbid
   schedule: "{{ .Values.server.config.daily_reboot.time }}"

--- a/charts/palworld/templates/deployments.yaml
+++ b/charts/palworld/templates/deployments.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   name: "{{ .Release.Name }}-server"
 spec:
   selector:

--- a/charts/palworld/templates/pvcs.yaml
+++ b/charts/palworld/templates/pvcs.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   name: "{{ .Release.Name }}-datadir-pvc"
   annotations:
     {{- with .Values.server.config.annotations }}

--- a/charts/palworld/templates/role.yaml
+++ b/charts/palworld/templates/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
     name: "{{ .Values.server.config.daily_reboot.role }}"
-    namespace: {{ .Values.namespace }}
+    namespace: {{ .Release.Namespace }}
 rules:
     - apiGroups: ["apps", "extensions"]
       resources: ["deployments", "pods"]

--- a/charts/palworld/templates/rolebinding.yaml
+++ b/charts/palworld/templates/rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: "{{ .Values.server.config.daily_reboot.role }}-binding"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -11,5 +11,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.server.config.daily_reboot.serviceAccount }}
-    namespace: {{ .Values.namespace }}
+    namespace: {{ .Release.Namespace }}
 {{ end }}

--- a/charts/palworld/templates/secrets.yaml
+++ b/charts/palworld/templates/secrets.yaml
@@ -8,7 +8,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   name: "{{ .Release.Name }}-rcon-password"
   annotations:
     {{- with .Values.server.config.annotations }}

--- a/charts/palworld/templates/serviceaccount.yaml
+++ b/charts/palworld/templates/serviceaccount.yaml
@@ -3,5 +3,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.server.config.daily_reboot.serviceAccount }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 {{ end }}

--- a/charts/palworld/templates/services.yaml
+++ b/charts/palworld/templates/services.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   name: "{{ .Release.Name }}-svc"
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}


### PR DESCRIPTION
# Motivations
`values.yaml` no longer has a `namespace` value, but it is still used in the chart. This PR changes these usages to utilize the Helm-provided namespace that the user specified at install time.

# Modifications
- This is basically one big `sed s/.Values.namespace/.Release.Namespace/g`