### PR TITLE
feat: add support for readiness and liveness probes

### DIFF
--- a/charts/palworld/templates/deployments.yaml
+++ b/charts/palworld/templates/deployments.yaml
@@ -56,6 +56,14 @@ spec:
             {{- with .Values.server.ports }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.server.probes.liveness }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.server.probes.readiness }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: ADMIN_PASSWORD
               valueFrom:

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -52,6 +52,23 @@ server:
   #
   strategy: Recreate
 
+  # Liveness and readiness probes
+  probes: {}
+    # liveness:
+    #   exec:
+    #     command:
+    #     - sh
+    #     - -c
+    #     - pgrep PalServer-Linux > /dev/null || exit 1
+    #   initialDelaySeconds: 30
+    # readiness:
+    #   exec:
+    #     command:
+    #     - sh
+    #     - -c
+    #     - rcon-cli Info | grep -q "Welcome to Pal Server"
+    #   initialDelaySeconds: 60
+
   # Service configuration
   #
   service:


### PR DESCRIPTION
# Motivations
Gives Kubernetes better indications of the current state of the deployment. 

# Modifications
- Allows users to specify readiness and liveness probes on the deployment. 
- This adds an example to the values.yaml in comments, but does not change the default of no probes
- The timing of the probes will be quite variable as some startups require a download that is limited by the speed of the user's network, so trying to choose sane defaults for all users could lead to unnecessarily long startup times for users on faster networks as the `initialDelayPeriod` ticks down