### PR TITLE
fix(deployment): avoid running rcon-cli if RCON not enabled

### DIFF
--- a/charts/palworld/templates/configmaps.yaml
+++ b/charts/palworld/templates/configmaps.yaml
@@ -50,10 +50,11 @@ data:
   restart-deployment.sh:  |
     #!/bin/bash
     set -euo pipefail
+  {{- if .Values.server.config.rcon.enable }}
     cont=$(kubectl -n {{ .Release.Namespace }} get pods -o=jsonpath='{.items[?(@.metadata.labels.app\.kubernetes\.io/name=="{{ .Release.Name }}-server")].metadata.name}')
     
     function exec_rcon_cmd() {
-      kubectl exec -n {{ .Release.Namespace }} -i pod/$cont rcon-cli "$1"
+      kubectl exec -n {{ .Release.Namespace }} -i pod/$cont -- rcon-cli "$1"
     }
 
     function exec_container_cmd() {
@@ -75,6 +76,7 @@ data:
 
     exec_rcon_cmd "Shutdown 1"
     sleep 30
+  {{ end }}
     kubectl -n {{ .Release.Namespace }} rollout restart deployment/{{ .Release.Name }}-server
   {{ end }}
   {{ end }}

--- a/charts/palworld/templates/configmaps.yaml
+++ b/charts/palworld/templates/configmaps.yaml
@@ -65,9 +65,11 @@ data:
     exec_rcon_cmd save
     sleep 30
     exec_rcon_cmd "Broadcast Backing_up_Server_Data..."
+  {{ end }}
     exec_container_cmd backup
     sleep 30
 
+  {{- if .Values.server.config.rcon.enable }}
     step=5
     for i in $(seq {{ .Values.server.config.daily_reboot.countdown_seconds }} -$step 1); do
       exec_rcon_cmd "Broadcast Rebooting_in_${i}_seconds..."

--- a/charts/palworld/templates/deployments.yaml
+++ b/charts/palworld/templates/deployments.yaml
@@ -62,6 +62,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
+            {{- if .Values.server.config.rcon.enable }}
             - name: ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -72,6 +73,7 @@ spec:
                   name: "{{ .Values.server.config.rcon.externalPassword.name }}"
                   key: "{{ .Values.server.config.rcon.externalPassword.key }}"
                 {{- end }}
+            {{- end }}
             {{- if .Values.server.config.community.enable }}
             - name: SERVER_PASSWORD
               valueFrom:

--- a/charts/palworld/templates/role.yaml
+++ b/charts/palworld/templates/role.yaml
@@ -5,10 +5,16 @@ metadata:
     name: "{{ .Values.server.config.daily_reboot.role }}"
     namespace: {{ .Release.Namespace }}
 rules:
-    - apiGroups: ["apps", "extensions"]
-      resources: ["deployments", "pods"]
-      verbs: ["get", "patch", "list", "watch"]
+    - apiGroups: ["apps"]
+      resources: ["deployments"]
+      resourceNames: ["{{ .Release.Name }}-server"]
+      verbs: ["get", "patch"]
+  {{- if .Values.server.config.rcon.enable }}
+    - apiGroups: [""]
+      resources: ["pods"]
+      verbs: ["get", "list"]
     - apiGroups:  [""]
-      resources:  ["pods/exec", "pods"]
-      verbs:  ["get", "list", "create"]
+      resources:  ["pods/exec"]
+      verbs:  ["create"]
+  {{- end }}
 {{ end }}

--- a/charts/palworld/templates/secrets.yaml
+++ b/charts/palworld/templates/secrets.yaml
@@ -4,7 +4,7 @@
 {{- define "server.community.password" -}}
 {{- randAlphaNum 24 | nospace -}}
 {{- end -}}
-{{- if not .Values.server.config.rcon.externalPassword }}
+{{- if and (not .Values.server.config.rcon.externalPassword) .Values.server.config.rcon.enable }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -75,9 +75,8 @@ server:
     preStop:
       exec:
         command:
-          - "sh"
-          - "-c"
-          - rcon-cli save && backup
+          - bash
+          - /usr/local/bin/backup
 
   # Service configuration
   #


### PR DESCRIPTION
# Motivations
 Avoid running `rcon-cli` in cases where RCON is disabled

# Modifications
- Doesn't set `AdminPassword` (which is the rcon password in the palworld config) when RCON is disabled
- Avoids creating an rcon secret
- uses a minimal daily reboot script that doesn't use rcon
- uses a minimal `Role` for the newly-limited daily reboot and minimizes the permissions of the existing role to only those required
- avoids running `rcon-cli save` on lifecycle exit, as the container already runs save on exit (https://github.com/thijsvanloef/palworld-server-docker/blob/main/scripts/init.sh#L31-L32) and the `backup` script does the same (https://github.com/thijsvanloef/palworld-server-docker/blob/main/scripts/backup.sh#L6-L7)
- fixes deprecation warning from `kubectl`: `kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead`