### PR TITLE
fix(configmap): daily-reboot: backup isn't a palworld rcon command

### DIFF
--- a/charts/palworld/templates/configmaps.yaml
+++ b/charts/palworld/templates/configmaps.yaml
@@ -54,12 +54,16 @@ data:
     function exec_rcon_cmd() {
       kubectl exec -n {{ .Release.Namespace }} -i pod/$cont rcon-cli "$1"
     }
-    
+
+    function exec_container_cmd() {
+      kubectl exec -n {{ .Release.Namespace }} -i pod/$cont -- "$1"
+    }
+
     exec_rcon_cmd "Broadcast Saving_Server_Data..."
     exec_rcon_cmd save
     sleep 30
     exec_rcon_cmd "Broadcast Backing_up_Server_Data..."
-    exec_rcon_cmd backup
+    exec_container_cmd backup
     sleep 30
 
     step=5

--- a/charts/palworld/templates/configmaps.yaml
+++ b/charts/palworld/templates/configmaps.yaml
@@ -69,7 +69,7 @@ data:
 
     step=5
     for i in $(seq {{ .Values.server.config.daily_reboot.countdown_seconds }} -$step 1); do
-      exec_rcon_cmd "Broadcast Rebooting_in_$i_seconds..."
+      exec_rcon_cmd "Broadcast Rebooting_in_${i}_seconds..."
       sleep $step
     done
 

--- a/charts/palworld/templates/configmaps.yaml
+++ b/charts/palworld/templates/configmaps.yaml
@@ -49,6 +49,7 @@ data:
   {{ if .Values.server.config.daily_reboot.enable }}
   restart-deployment.sh:  |
     #!/bin/bash
+    set -euo pipefail
     cont=$(kubectl -n {{ .Release.Namespace }} get pods -o=jsonpath='{.items[?(@.metadata.labels.app\.kubernetes\.io/name=="{{ .Release.Name }}-server")].metadata.name}')
     
     function exec_rcon_cmd() {

--- a/charts/palworld/templates/secrets.yaml
+++ b/charts/palworld/templates/secrets.yaml
@@ -33,7 +33,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   name: "{{ .Release.Name }}-community-password"
   annotations:
     {{- with .Values.server.config.annotations }}


### PR DESCRIPTION
# Motivations
This fixes an issue where the `backup` command is used via rcon, which doesn't exist.

# Modifications
- This PR fixes the above issue and adds a `set -euo pipefail` line to the script to help catch things like this. This has the following effects:
- The `set -e` option instructs bash to immediately exit if any command returns a non-zero exit status, which will mark the pod as failed so k8s can handle it appropriately. This would have caught the `backup` command being sent to rcon
- `set -u` affects variables. When set, a reference to any variable you haven't previously defined will error. This is useful for catching variable typos, this caught an issue I describe below
- `set -o pipefail` turns on the `pipefail` option which prevents errors in a pipeline from being masked. If any command in a pipeline fails, that return code will be used as the return code of the whole pipeline. For example `exit 1 | sort` would continue execution without `set -o pipefail` when it should be treated as an error.
- `set -u` found that interpolation wasn't quite working on the countdown: `i_seconds: unbound variable`. This caused the countdown to not broadcast to players correctly. This PR fixes this