### PR TITLE
Configurable announcement countdown

### DIFF
--- a/charts/palworld/templates/configmaps.yaml
+++ b/charts/palworld/templates/configmaps.yaml
@@ -63,7 +63,7 @@ data:
     sleep 30
 
     step=5
-    for i in $(seq 30 -$step 1); do
+    for i in $(seq {{ .Values.server.config.daily_reboot.countdown_seconds }} -$step 1); do
       exec_rcon_cmd "Broadcast Rebooting_in_$i_seconds..."
       sleep $step
     done

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -144,6 +144,8 @@ server:
     daily_reboot:
       enable: false
 
+      countdown_seconds: 30
+
       # UTC cron syntax for server reboot schedule, https://crontab.guru/
       # Defaults to 9:30am UTC
       #

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -144,6 +144,7 @@ server:
     daily_reboot:
       enable: false
 
+      # Countdown in seconds to announce to players before the server is rebooted
       countdown_seconds: 30
 
       # UTC cron syntax for server reboot schedule, https://crontab.guru/


### PR DESCRIPTION
# Motivations
Allows the announcement countdown in `daily-reboot` to be configured. Some encounters can keep the player occupied for more than 30 seconds, so I would like to increase this to a much larger value.

# Modifications
- Adds a `server.config.daily_reboot.countdown_seconds` option which is injected in `restart-deployment.sh` on the ConfigMap
