### PR TITLE
feat: make container lifecycle configurable

### DIFF
--- a/charts/palworld/templates/deployments.yaml
+++ b/charts/palworld/templates/deployments.yaml
@@ -41,13 +41,10 @@ spec:
         - name: server
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: {{ .Values.server.image.imagePullPolicy }}
+          {{- with .Values.server.lifecycle }}
           lifecycle:
-            preStop:
-              exec:
-                command:
-                  - "sh"
-                  - "-c"
-                  - rcon-cli save && backup
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- with .Values.server.resources }}
               {{- toYaml . | nindent 12 }}

--- a/charts/palworld/templates/deployments.yaml
+++ b/charts/palworld/templates/deployments.yaml
@@ -90,6 +90,7 @@ spec:
           volumeMounts:
             - mountPath: /palworld
               name: datadir
+      terminationGracePeriodSeconds: {{ .Values.server.terminationGracePeriodSeconds }}
       {{- with .Values.server.image.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -70,6 +70,7 @@ server:
     #   initialDelaySeconds: 60
 
   # Container lifecycle
+  terminationGracePeriodSeconds: 30
   lifecycle:
     preStop:
       exec:

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -69,6 +69,15 @@ server:
     #     - rcon-cli Info | grep -q "Welcome to Pal Server"
     #   initialDelaySeconds: 60
 
+  # Container lifecycle
+  lifecycle:
+    preStop:
+      exec:
+        command:
+          - "sh"
+          - "-c"
+          - rcon-cli save && backup
+
   # Service configuration
   #
   service:


### PR DESCRIPTION
# Motivations
I would like to send custom broadcast messages from the pre-stop hook.

# Modifications
- This PR moves the current Deployment's container `lifecycle` to the values under `server.lifecycle` and makes the default the previous default values
- Makes the `terminationGracePeriodSeconds` configurable to allow long-running `preStop` lifecycle hooks
