### PR TITLE
fix(ci): pr-tests: ignore lack of version bump

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -32,7 +32,7 @@ jobs:
           fi
 
       - name: Helm - chart-testing - lint
-        run: ct lint --config ct.yaml
+        run: ct lint --check-version-increment false --config ct.yaml
 
   e2e-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Motivations
Versioning should be done by the maintainer and not in user-submitted PRs.

# Modifications
- Instructs `ct lint` to ignore version bump requirements. https://github.com/helm/chart-testing/blob/main/doc/ct_lint.md details the `--check-version-increment` flag
