### PR TITLE
fix(ci): pr-tests: use proper syntax for `ct` argument

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -32,7 +32,7 @@ jobs:
           fi
 
       - name: Helm - chart-testing - lint
-        run: ct lint --check-version-increment false --config ct.yaml
+        run: ct lint --check-version-increment=false --config ct.yaml
 
   e2e-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Motivations
Looks like my previous PR didn't work due to <https://github.com/helm/chart-testing/issues/363>. Action run https://github.com/Twinki14/palworld-server-chart/actions/runs/7983177116/job/21797898143?pr=20 runs lint with this command now working

# Modifications
- Uses different flag syntax for `ct lint`
