### PR TITLE
daily-reboot: fix scripting mistake

### DIFF
--- a/charts/palworld/templates/configmaps.yaml
+++ b/charts/palworld/templates/configmaps.yaml
@@ -50,15 +50,16 @@ data:
   restart-deployment.sh:  |
     #!/bin/bash
     set -euo pipefail
-  {{- if .Values.server.config.rcon.enable }}
+
     cont=$(kubectl -n {{ .Release.Namespace }} get pods -o=jsonpath='{.items[?(@.metadata.labels.app\.kubernetes\.io/name=="{{ .Release.Name }}-server")].metadata.name}')
-    
-    function exec_rcon_cmd() {
-      kubectl exec -n {{ .Release.Namespace }} -i pod/$cont -- rcon-cli "$1"
-    }
 
     function exec_container_cmd() {
       kubectl exec -n {{ .Release.Namespace }} -i pod/$cont -- "$1"
+    }
+
+  {{- if .Values.server.config.rcon.enable }}
+    function exec_rcon_cmd() {
+      kubectl exec -n {{ .Release.Namespace }} -i pod/$cont -- rcon-cli "$1"
     }
 
     exec_rcon_cmd "Broadcast Saving_Server_Data..."

--- a/charts/palworld/templates/role.yaml
+++ b/charts/palworld/templates/role.yaml
@@ -9,12 +9,10 @@ rules:
       resources: ["deployments"]
       resourceNames: ["{{ .Release.Name }}-server"]
       verbs: ["get", "patch"]
-  {{- if .Values.server.config.rcon.enable }}
     - apiGroups: [""]
       resources: ["pods"]
       verbs: ["get", "list"]
     - apiGroups:  [""]
       resources:  ["pods/exec"]
       verbs:  ["create"]
-  {{- end }}
 {{ end }}


### PR DESCRIPTION
# Motivations
My previous #14 forgot to move the definition of `exec_container_cmd` out of the conditional statment

# Modifications
- Fixes the above issue by reordering the script

Before:

```bash
#!/bin/bash
set -euo pipefail
exec_container_cmd backup
sleep 30
kubectl -n palworld rollout restart deployment/palworld-server
```

After:

```bash
set -euo pipefail

cont=$(kubectl -n palworld get pods -o=jsonpath='{.items[?(@.metadata.labels.app\.kubernetes\.io/name=="palworld-server")].metadata.name}')

function exec_container_cmd() {
  kubectl exec -n palworld -i pod/$cont -- "$1"
}
exec_container_cmd backup
sleep 30
kubectl -n palworld rollout restart deployment/palworld-server
```
