### PR TITLE
split daily-reboot script to it's own configmap

### DIFF
--- a/charts/palworld/templates/configmaps.yaml
+++ b/charts/palworld/templates/configmaps.yaml
@@ -46,7 +46,21 @@ data:
   {{- with .Values.server.config.env }}
   {{- toYaml . | nindent 2  }}
   {{- end }}
-  {{ if .Values.server.config.daily_reboot.enable }}
+---
+{{ if .Values.server.config.daily_reboot.enable }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: "{{ .Release.Name }}-restart-deployment"
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: "{{ .Release.Name }}-restart-deployment"
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "{{ .Release.Name }}-restart-deployment"
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+data:
   restart-deployment.sh:  |
     #!/bin/bash
     set -euo pipefail
@@ -81,4 +95,4 @@ data:
   {{ end }}
     kubectl -n {{ .Release.Namespace }} rollout restart deployment/{{ .Release.Name }}-server
   {{ end }}
-  {{ end }}
+{{ end }}

--- a/charts/palworld/templates/cronjob.yaml
+++ b/charts/palworld/templates/cronjob.yaml
@@ -29,7 +29,7 @@ spec:
           volumes:
           - name: restart-script
             configMap:
-              name: "{{ .Release.Name }}-env-config"
+              name: "{{ .Release.Name }}-restart-deployment"
               defaultMode:  0777
               items:
               - key:  "restart-deployment.sh"


### PR DESCRIPTION
This is the last thing on my TODOs/Wants list other than #12 before all my usecases are handled.

#22 should be first

# Motivations
Avoids putting the script in the container as an environment variable:

```bash
$ k exec -it deployments/palworld-server -- env | grep -i restart-deployment
restart-deployment.sh=#!/bin/bash
```

# Modifications
- Adds a new configmap with the script, removes it from the old config, and changes the cronjob to refer to the new configmap
