### PR TITLE
feat: allow broader storage configuration

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -73,4 +73,4 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Helm - chart-testing - install
-        run: ct install --config ct.yaml --helm-extra-set-args='--set=server.resources=null --set=server.storage.size=3Gi'
+        run: ct install --config ct.yaml --helm-extra-set-args='--set=server.resources=null --set=server.storage.main.size=3Gi'

--- a/charts/palworld/templates/deployments.yaml
+++ b/charts/palworld/templates/deployments.yaml
@@ -92,6 +92,16 @@ spec:
           volumeMounts:
             - mountPath: /palworld
               name: datadir
+            {{- if .Values.server.storage.backups }}
+            - mountPath: /palworld/backups
+              name: backups
+            {{- end }}
+            {{- range $index, $element := .Values.server.storage.extra }}
+            - mountPath: {{ $element.mountPath }}
+              readOnly: {{ $element.readOnly | default false }}
+              subPath: {{ $element.subPath | default "" }}
+              name: {{ $element.name }}
+            {{- end }}
       terminationGracePeriodSeconds: {{ .Values.server.terminationGracePeriodSeconds }}
       {{- with .Values.server.image.imagePullSecrets }}
       imagePullSecrets:
@@ -100,8 +110,143 @@ spec:
       volumes:
         - name: datadir
           persistentVolumeClaim:
-            {{- if not .Values.server.storage.external }}
+            {{- if not .Values.server.storage.main.external }}
             claimName: "{{ .Release.Name }}-datadir-pvc"
+            {{ else }}
+            claimName: "{{ .Values.server.storage.main.externalName }}"
+            {{ end }}
+        {{- if .Values.server.storage.backups }}
+        - name: backups
+          {{- if .Values.server.storage.backups.persistentVolumeClaim }}
+          persistentVolumeClaim:
+            {{- if and .Values.server.storage.backups.persistentVolumeClaim (not .Values.server.storage.backups.persistentVolumeClaim.external) }}
+            claimName: "{{ .Release.Name }}-backups-pvc"
             {{ else }}
             claimName: "{{ .Values.server.storage.externalName }}"
             {{ end }}
+          {{- else }}
+          {{ with .Values.server.storage.backups }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{ end }}
+        {{- end }}
+        {{- range $index, $element := .Values.server.storage.extra }}
+        {{- if $element.persistentVolumeClaim }}
+        - name: {{ $element.name }}
+          {{- if not $element.persistentVolumeClaim.external }}
+          persistentVolumeClaim:
+            claimName: "{{ $.Release.Name }}-{{ $element.name }}-pvc"
+          {{- else }}
+          persistentVolumeClaim:
+            claimName: "{{ $element.externalName }}"
+          {{- end }}
+        {{- else if $element.configMap }}
+        - name: {{ $element.name }}
+          configMap:
+            {{- toYaml $element.configMap | nindent 12 }}
+        {{- else if $element.secret }}
+        - name: {{ $element.name }}
+          secret:
+            {{- toYaml $element.secret | nindent 12 }}
+        {{- else if $element.downwardAPI }}
+        - name: {{ $element.name }}
+          downwardAPI:
+            {{- toYaml $element.downwardAPI | nindent 12 }}
+        {{- else if $element.projected }}
+        - name: {{ $element.name }}
+          projected:
+            {{- toYaml $element.projected | nindent 12 }}
+        {{- else if $element.emptyDir }}
+        - name: {{ $element.name }}
+          emptyDir:
+            {{- toYaml $element.emptyDir | nindent 12 }}
+        {{- else if $element.hostPath }}
+        - name: {{ $element.name }}
+          hostPath:
+            {{- toYaml $element.hostPath | nindent 12 }}
+        {{- else if $element.awsElasticBlockStore }}
+        - name: {{ $element.name }}
+          awsElasticBlockStore:
+            {{- toYaml $element.awsElasticBlockStore | nindent 12 }}
+        {{- else if $element.azureDisk }}
+        - name: {{ $element.name }}
+          azureDisk:
+            {{- toYaml $element.azureDisk | nindent 12 }}
+        {{- else if $element.azureFile }}
+        - name: {{ $element.name }}
+          azureFile:
+            {{- toYaml $element.azureFile | nindent 12 }}
+        {{- else if $element.cephfs }}
+        - name: {{ $element.name }}
+          cephfs:
+            {{- toYaml $element.cephfs | nindent 12 }}
+        {{- else if $element.cinder }}
+        - name: {{ $element.name }}
+          cinder:
+            {{- toYaml $element.cinder | nindent 12 }}
+        {{- else if $element.csi }}
+        - name: {{ $element.name }}
+          csi:
+            {{- toYaml $element.csi | nindent 12 }}
+        {{- else if $element.ephemeral }}
+        - name: {{ $element.name }}
+          ephemeral:
+            {{- toYaml $element.ephemeral | nindent 12 }}
+        {{- else if $element.fc }}
+        - name: {{ $element.name }}
+          fc:
+            {{- toYaml $element.fc | nindent 12 }}
+        {{- else if $element.flexVolume }}
+        - name: {{ $element.name }}
+          flexVolume:
+            {{- toYaml $element.flexVolume | nindent 12 }}
+        {{- else if $element.flocker }}
+        - name: {{ $element.name }}
+          flocker:
+            {{- toYaml $element.flocker | nindent 12 }}
+        {{- else if $element.gcePersistentDisk }}
+        - name: {{ $element.name }}
+          gcePersistentDisk:
+            {{- toYaml $element.gcePersistentDisk | nindent 12 }}
+        {{- else if $element.glusterfs }}
+        - name: {{ $element.name }}
+          glusterfs:
+            {{- toYaml $element.glusterfs | nindent 12 }}
+        {{- else if $element.iscsi }}
+        - name: {{ $element.name }}
+          iscsi:
+            {{- toYaml $element.iscsi | nindent 12 }}
+        {{- else if $element.nfs }}
+        - name: {{ $element.name }}
+          nfs:
+            {{- toYaml $element.nfs | nindent 12 }}
+        {{- else if $element.photonPersistentDisk }}
+        - name: {{ $element.name }}
+          photonPersistentDisk:
+            {{- toYaml $element.photonPersistentDisk | nindent 12 }}
+        {{- else if $element.portworxVolume }}
+        - name: {{ $element.name }}
+          portworxVolume:
+            {{- toYaml $element.portworxVolume | nindent 12 }}
+        {{- else if $element.quobyte }}
+        - name: {{ $element.name }}
+          quobyte:
+            {{- toYaml $element.quobyte | nindent 12 }}
+        {{- else if $element.rbd }}
+        - name: {{ $element.name }}
+          rbd:
+            {{- toYaml $element.rbd | nindent 12 }}
+        {{- else if $element.scaleIO }}
+        - name: {{ $element.name }}
+          scaleIO:
+            {{- toYaml $element.scaleIO | nindent 12 }}
+        {{- else if $element.storageos }}
+        - name: {{ $element.name }}
+          storageos:
+            {{- toYaml $element.storageos | nindent 12 }}
+        {{- else if $element.vsphereVolume }}
+        - name: {{ $element.name }}
+          vsphereVolume:
+            {{- toYaml $element.vsphereVolume | nindent 12 }}
+        {{ end }}
+        {{- end }}

--- a/charts/palworld/templates/pvcs.yaml
+++ b/charts/palworld/templates/pvcs.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.server.storage.external }}
+{{- if not .Values.server.storage.main.external }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "{{ .Release.Name }}-datadir-pvc"
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
-    {{- if .Values.server.storage.preventDelete }}
+    {{- if .Values.server.storage.main.preventDelete }}
     helm.sh/resource-policy: keep
     {{ end }}
     {{- with .Values.server.config.labels }}
@@ -26,6 +26,72 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: {{ .Values.server.storage.size }}
-  storageClassName: {{ .Values.server.storage.storageClassName }}
+      storage: {{ .Values.server.storage.main.size }}
+  storageClassName: {{ .Values.server.storage.main.storageClassName }}
+{{ end }}
+---
+{{- if and .Values.server.storage.backups.persistentVolumeClaim (not .Values.server.storage.backups.persistentVolumeClaim.external) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: "{{ .Release.Name }}-backups-pvc"
+  annotations:
+    {{- with .Values.server.config.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: "{{ .Release.Name }}-backups-pvc"
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "{{ .Release.Name }}-backups-pvc"
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- if .Values.server.storage.backups.persistentVolumeClaim.preventDelete }}
+    helm.sh/resource-policy: keep
+    {{ end }}
+    {{- with .Values.server.config.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.server.storage.backups.persistentVolumeClaim.size }}
+  storageClassName: {{ .Values.server.storage.backups.persistentVolumeClaim.storageClassName }}
+{{ end }}
+---
+{{- range $index, $element := .Values.server.storage.extra }}
+{{- if and $element.persistentVolumeClaim (not $element.external) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: {{ $.Release.Namespace }}
+  name: "{{ $.Release.Name }}-{{ $element.name }}-pvc"
+  annotations:
+    {{- with $.Values.server.config.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: "{{ $.Release.Name }}-{{ $element.name }}-pvc"
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/component: "{{ $.Release.Name }}-{{ $element.name }}-pvc"
+    app.kubernetes.io/version: {{ $.Chart.AppVersion }}
+    {{- if $element.preventDelete }}
+    helm.sh/resource-policy: keep
+    {{ end }}
+    {{- with $.Values.server.config.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ $element.size }}
+  storageClassName: {{ $element.storageClassName }}
+{{ end }}
 {{ end }}

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -14,15 +14,84 @@ server:
   # Storage definitions related to the palworld-server
   #
   storage:
-    external: false
-    externalName: ""
+    main:
+      external: false
+      externalName: ""
 
-    # Keeps helm from deleting the PVC, by default helm does not delete pvcs
+      # Keeps helm from deleting the PVC, by default helm does not delete pvcs
+      #
+      preventDelete: false
+
+      size: 12Gi
+      storageClassName: ""
+
+    # If not specified, the backups will be stored on the `main` storage
     #
-    preventDelete: false
+    # Supports all storage types as defined by https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/#Volume
+    #
+    # `persistentVolumeClaim` is a special case that matches the `main` storage in definition
+    backups: {}
+      # persistentVolumeClaim:
+      #   external: false
+      #   externalName: ""
+      #   preventDelete: false
+      #   size: 12Gi
+      #   storageClassName: ""
 
-    size: 12Gi
-    storageClassName: ""
+      # nfs:
+      #   server: your.server.ip
+      #   path: /path/to/remote/dir
+
+    # Additional storage definitions
+    #
+    # Supports all storage types as defined by https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/#Volume
+    #
+    # THe objects supports configuring the mount path and the subpath.
+    # If external isn't true, the defined deletion prevention, storage class, and size will be used to create a new PVC
+    extra: []
+
+    # An example of using an existing PVC at a subpath
+    #
+    # - name: existing-pvc
+    #   mountPath: /existing-pvc
+    #   subPath: test
+    #   external: true
+    #   persistentVolumeClaim:
+    #     claimName: existing-pvc
+
+    # An example of creating a new PVC of 5Gi
+    #
+    # - name: new-pvc
+    #   mountPath: /new-pvc
+    #   size: 5Gi
+    #   preventDelete: false
+    #   storageClassName: "my-storage-class"
+    #   persistentVolumeClaim:
+    #     claimName: new-pvc
+
+    # An example of mounting a configmap with key `test.ini` as `config.ini` in /config
+    #
+    # - name: config
+    #   mountPath: /config
+    #   configMap:
+    #     name: app-configfile
+    #     items:
+    #     - key: test.ini
+    #       path: config.ini
+
+    # An example of mounting a secret
+    # - name: keys
+    #   mountPath: /keys
+    #   readOnly: true
+    #   secret:
+    #     secretName: app-keyfile
+
+    # An example of mounting an nfs volume
+    # - name: nfs
+    #   mountPath: /data
+    #   nfs:
+    #     server: your.server.ip
+    #     path: /path/to/dir
 
   # Docker image used for the palworld-server deployment
   #


### PR DESCRIPTION
Fixes #12 

# Motivations
Discussed in #12

# Modifications

This PR changes the structure of the `server.storage` block and is therefore a breaking change.

This takes the existing storage config (below for reference):
```
server:
  # Storage definitions related to the palworld-server
  #
  storage:
    external: false
    externalName: ""

    # Keeps helm from deleting the PVC, by default helm does not delete pvcs
    #
    preventDelete: false

    size: 12Gi
    storageClassName: ""
```

and modifies it to the following, basically moving it under `main`.

```
server:
  # Storage definitions related to the palworld-server
  #
  storage:
    main:
      external: false
      externalName: ""

      # Keeps helm from deleting the PVC, by default helm does not delete pvcs
      #
      preventDelete: false

      size: 12Gi
      storageClassName: ""
```

---

Then we have the `backups` key, which supports any Kubernetes [Volume spec](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/#Volume) as it's body. The `persistentVolumeClaim` is a special case which matches the schema of `server.storage.main` rather than the Kubernetes Volume spec

```
server:
  storage:
    backups: {}
      # persistentVolumeClaim:
      #   external: false
      #   externalName: ""
      #   preventDelete: false
      #   size: 12Gi
      #   storageClassName: ""

      # nfs:
      #   server: your.server.ip
      #   path: /path/to/remote/dir
```

---

Finally, we have the `extra` array. This takes a list of objects where `name` and `mountPath` are required, along with a Kubernetes volume spec. In `extra`, the `subPath` and `readOnly` of the volume mounts on the deployment are configurable. If a `persistentVolumeClaim` is used, `external` can be set to not provision a new PVC, otherwise `size`, `storageClassName`, and `preventDelete` can be used to modify the provisioned PVC. The `values.yaml` shows several commented examples of this: <https://github.com/Twinki14/palworld-server-chart/blob/5fae7415b4228c05a1ebc091e4e032342d65f9ea/charts/palworld/values.yaml#L45-L94>