### PR TITLE
add template for updating security context of pods in deployment

### DIFF
--- a/charts/palworld/templates/deployments.yaml
+++ b/charts/palworld/templates/deployments.yaml
@@ -250,3 +250,7 @@ spec:
             {{- toYaml $element.vsphereVolume | nindent 12 }}
         {{ end }}
         {{- end }}
+      securityContext:
+        {{- with .Values.server.securityContext }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -187,6 +187,9 @@ server:
       protocol: TCP
       targetPort: 25575
 
+  # Security context for the container
+  securityContext: {}
+
   # Palworld-server specific configuration
   #
   config:


### PR DESCRIPTION
# Motivations
I needed to update the uid+gid of the user running in the pod to prevent attempts to chown the palworld directory as my NFS doesn't allow that resulting in container restarts at startup

# Modifications
Added template options to update the security context of the pods running in the deployment